### PR TITLE
fix: show desktop nav at md breakpoint to remove header dead zone

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -15,7 +15,7 @@ export default function Header({ content, courses, progressService }) {
 
   return (
     <>
-      <Popover className="relative bg-white hidden lg:block">
+      <Popover className="relative bg-white hidden md:block">
         <div
           className="absolute inset-0 shadow z-30 pointer-events-none"
           aria-hidden="true"


### PR DESCRIPTION
The desktop header Popover used `hidden lg:block` (visible only >=1024px)
while the mobile nav uses `md:hidden` (visible only <768px), leaving a
768-1023px range where neither navigation renders. Cypress's default
viewport (1000x660) falls in this gap, so header/nav elements are
`display:none` and DOM snapshots show "One or more matched elements are
not visible" with a slashed-eye icon.

The header's inner layout is already built with `md:` classes, so the
outer wrapper should switch at `md` too. Changing `lg:block` to
`md:block` aligns the breakpoints (desktop nav >=768px, mobile nav
<768px), making the navigation visible at the default Cypress viewport.

Fixes #33

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GBB85wnAx63tuWToXYafBx