### PR TITLE
Bump TypeScript to ^5.0.0 to meet Cypress minimum

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@
 /.next/
 /out/
 
+# typescript
+*.tsbuildinfo
+
 # production
 /build
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "slugify": "^1.6.5",
         "tailwindcss": "^3.0.23",
         "tsconfig-paths": "^3.13.0",
-        "typescript": "^4.6.2",
+        "typescript": "^5.0.0",
         "unslugify": "^1.0.2",
         "url-loader": "^4.1.1"
       }
@@ -11389,16 +11389,17 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/unbox-primitive": {
@@ -20557,9 +20558,9 @@
       }
     },
     "typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true
     },
     "unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "slugify": "^1.6.5",
     "tailwindcss": "^3.0.23",
     "tsconfig-paths": "^3.13.0",
-    "typescript": "^4.6.2",
+    "typescript": "^5.0.0",
     "unslugify": "^1.0.2",
     "url-loader": "^4.1.1"
   }


### PR DESCRIPTION
Cypress 15.0.0 raised the minimum required TypeScript version from 4.0+
to 5.0+. Update the dependency from ^4.6.2 to ^5.0.0.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Jy7w2Bh1VvRtGJMcvcgY5o